### PR TITLE
Fix assert crash.  Fixed the out of memory build bug.

### DIFF
--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include <cmath>
+#include <cstddef>
 #include <cstdio>
 #include <iostream>
 #include <sstream>
@@ -572,6 +573,11 @@ int partition_with_ram_budget(const std::string data_file, const double sampling
 
         for (auto &p : cluster_sizes)
         {
+            if (0 == p)
+            {
+                num_parts--;
+                continue;
+            }
             // to account for the fact that p is the size of the shard over the
             // testing sample.
             p = (uint64_t)(p / sampling_rate);


### PR DESCRIPTION

Fix assert crash.
    index.cpp : 1052 assert(!pruned_list.empty());
    Build in scenarios with sufficient memory.
    If the pre-computed centroid is index=0, the composition fails.
    The composition strategy must be adjusted.

Fixed the out of memory build bug.
    Build in out of memory scenario. If the memory is between sufficient and
    insufficient memory. The code uses three builds by default, which may be
    less than three. It needs to be removed. Otherwise it crashes.


